### PR TITLE
Change config to enable easier reverse proxy

### DIFF
--- a/init/60_set_the_site.sh
+++ b/init/60_set_the_site.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-mkdir -p /config/www/gallery
-if [ -f "/config/www/gallery/index.php" ]; then
+mkdir -p /config/www/piwigo
+if [ -f "/config/www/piwigo/index.php" ]; then
 echo "using existing website"
 else
 echo "fetching piwigo files"
 wget "http://piwigo.org/download/dlcounter.php?code=latest" -O /tmp/piwigo.zip
 unzip -q /tmp/piwigo.zip  -d /tmp 
-mv /tmp/piwigo/* /config/www/gallery 
+mv /tmp/piwigo/* /config/www/piwigo 
 rm -rf /tmp/piwigo /tmp/piwigo.zip
-chown -R abc:abc /config/www/gallery
+chown -R abc:abc /config/www/piwigo
 fi
 
-if [ ! -f "/config/www/gallery/local/config/config.inc.php" ]; then
-cp /config/www/gallery/include/config_default.inc.php /config/www/gallery/local/config/config.inc.php
-chown abc:abc /config/www/gallery/local/config/config.inc.php
+if [ ! -f "/config/www/piwigo/local/config/config.inc.php" ]; then
+cp /config/www/piwigo/include/config_default.inc.php /config/www/piwigo/local/config/config.inc.php
+chown abc:abc /config/www/piwigo/local/config/config.inc.php
 fi


### PR DESCRIPTION
Sparklyballs take a look at this and the changes to default.conf.  Will mean the webui should be accessible on IP:PORT/piwigo  and will enable much easier reverse proxying with our Apache container