### PR TITLE
linuxserver/docker-piwigo#13 adding php-ldap to container build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN \
 	php7-pear \
 	php7-xmlrpc \
 	php7-xsl \
+        php7-ldap \
 	re2c \
 	unzip \
 	wget


### PR DESCRIPTION
Adding php-ldap to the installation process. I built and tested the installation of the plugin, but unfortunately do not have an active ldap server to actually full loop the plugin. 

