### PR TITLE
Update readme-vars.yml to include info for ftp-sync functionality

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -38,6 +38,8 @@ app_setup_block: "* You must create a user and database for piwigo to use in a m
 
 * The easiest way to edit the configuration file is to enable local files editor from the plugins page and use it to configure email settings etc."
 
+* When setting up a volume from your NAS to your docker instance.  If you would like to store photos on the NAS and use ftp-sync instead of web-upload, you should create a 'photos' folder in '/config/www/gallery/galleries/'.  The photos folder can then be symlinked to the shared volume folder using the command i.e. `ln -s /pictures/2021 2021`
+
 app_setup_nginx_reverse_proxy_snippet: false
 app_setup_nginx_reverse_proxy_block: ""
 


### PR DESCRIPTION
Looking at the https://github.com/linuxserver/docker-piwigo and under the 'application setup' section of the readme.md I would suggest adding some info on how to set-up ftp sync.  When installing on my machine I had trouble finding the included information.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ x ] I have read the [contributing](https://github.com/linuxserver/docker-piwigo/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
ftp-sync is by default to the galleries folder at '/config/www/gallery/galleries/'.  This works ok for installations on a physical machine but if photos are in a volume that is shared with the docker instance they need to be sym-linked to the galleries folder.  Directly sym-linking does not work, however if you make a 'photos' folder in the 'galleries' folder and make the symlink there, ftp sync will work.

i.e. for a folder with photos on your host that is shared to the /pictures/2020 folder of the container, setting up the sym-link like 
- `ln -s /pictures/2020 /config/www/gallery/galleries/photos/2020` will work while 
- `ln -s /pictures/2020 /config/www/gallery/galleries/2020` will not work.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This information is not available anywhere i could find.  If using piwigo without this method i believe the only fix would be modifying config files or using web-upload instead up bulk uploading with ftp-sync

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
raspberry pi 4 host
<!--- see how your change affects other areas of the code, etc. -->
it only affects the readme file

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
