### PR TITLE
Fix template-extension persistence

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -38,6 +38,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "16.01.23:", desc: "Fix broken custom template persistence." }
   - { date: "08.11.22:", desc: "Rebase to Alpine 3.16, migrate to s6v3. Move application install to /app/www/public, add migration for existing users. Container updates should now update the application correctly." }
   - { date: "20.08.22:", desc: "Rebasing to alpine 3.15 with php8. Restructure nginx configs ([see changes announcement](https://info.linuxserver.io/issues/2022-08-20-nginx-base))." }
   - { date: "29.06.21:", desc: "Rebase to 3.14, Add php7-zip package" }

--- a/root/etc/s6-overlay/s6-rc.d/init-piwigo-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-piwigo-config/run
@@ -16,6 +16,7 @@ if [[ -f /gallery/index.php ]]; then
     mv /gallery/plugins/ /config/www/plugins
     mv /gallery/themes/ /config/www/themes
     mv /gallery/local/ /config/www/local
+    mv /gallery/template-extension/ /config/www/template-extension
     rm /gallery/index.php
     rm /config/www/gallery
     sed -i "s|root /config/www/gallery;|root /app/www/public;|" /config/nginx/site-confs/default.conf
@@ -49,6 +50,7 @@ symlinks=( \
 /app/www/public/local \
 /app/www/public/themes \
 /app/www/public/_data \
+/app/www/public/template-extension \
 )
 
 for i in "${symlinks[@]}"; do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix broken custom template support by enabling back template-extension folder persistence

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-piwigo/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Fix the /etc/s6-overlay/s6-rc.d/init-piwigo-config/run script to also persist template-extension folder.
In Piwigo, templates can be customised. Before this fix, the customised templates were stored in the /app/www/public/template-extension folder and were not persisted. This PR reuses the existing logic to create a symlink from /app/www/public/template-extension that points to the /config/www/template-extension folder. The config folder is declared as a volume and is persisted.
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
The template customisation support was broken before this PR because the customised templates didn't get persisted. This PR enables back template customisation support. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new Docker image has been built locally and tested manually. It has been then deployed to a private production server where the custom template persistence issue has successfully been fixed. No side effect found or expected.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->