### PR TITLE
Fix HEIC file format support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN \
     exiftool \
     ffmpeg \
     imagemagick \
+    imagemagick-heic \
     libjpeg-turbo-utils \
     mediainfo \
     php83-apcu \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,6 +15,7 @@ RUN \
     exiftool \
     ffmpeg \
     imagemagick \
+    imagemagick-heic \
     libjpeg-turbo-utils \
     mediainfo \
     php83-apcu \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -37,6 +37,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "02.03.24:", desc: "Fix HEIC file format support."}
   - { date: "23.12.23:", desc: "Rebase to Alpine 3.19 with php 8.3."}
   - { date: "12.12.23:", desc: "Rebase to Alpine 3.18." }
   - { date: "03.06.23:", desc: "Revert to Alpine 3.17 due to compatibility issues with php 8.2." }


### PR DESCRIPTION
Fix broken HEIC file format support by adding the missing imagemagick-heic package

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-piwigo/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Install the imagemagick-heic package during the build process.
On alpine 3.18, imagemagick was supporting the HEIC file format by default. 
Since alpine 3.19, the HEIC file format support requires the imagemagick-heic package to be installed.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Piwigo 14.0 has introduced the support for the HEIC file format.
This feature was working fine when ghcr.io/linuxserver/baseimage-alpine-nginx:3.18 was used as a base image.
However, since the upgrade to ghcr.io/linuxserver/baseimage-alpine-nginx:3.19, the HEIC file support is broken: the HEIC representative generation fails silently and the uploaded HEIC image is just shown as a document with a question mark in the gallery.
Once the imagemagick-heic package gets installed, the HEIC representative generation works again and the image is properly displayed in the gallery.

## How Has This Been Tested?
The new Docker image has been built locally and tested manually. It has been then deployed to a private production server where the HEIC representative file generation issue has successfully been fixed. No side effect found or expected.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->